### PR TITLE
Crash and hang fixes

### DIFF
--- a/src/trans_rdma.c
+++ b/src/trans_rdma.c
@@ -1186,7 +1186,8 @@ static void *msk_cq_thread(void *arg) {
 			msk_mutex_lock(trans->debug & MSK_DEBUG_CM_LOCKS, &trans->cm_lock);
 			if (trans->state >= MSK_CLOSING) { /* CLOSING, CLOSED, ERROR */
 				// closing trans, skip this, will be done on flush
-				msk_cq_delfd(trans);
+				if (trans->comp_channel)
+					msk_cq_delfd(trans);
 				msk_mutex_unlock(trans->debug & MSK_DEBUG_CM_LOCKS, &trans->cm_lock);
 				continue;
 			}


### PR DESCRIPTION
This pull request fixes one crash and one hang observed while using Mooshika.

- One crash in msk_cq_thread() which calls msk_cq_delfd() without checking if comp_channel is still there
- One hang in msk_trans_destroy() in the case rdma_disconnect() failed. The trans state won't change (no cm event issued), then msk_trans_destroy() may wait forever on the msk_cond_wait() following the rdma_disconnect() call.

See commit logs for a bit more details.