### PR TITLE
src/trans_shm.c: remove obsoletes infiniband/arch.h header

### DIFF
--- a/src/trans_shm.c
+++ b/src/trans_shm.c
@@ -44,7 +44,6 @@
 #include <sys/shm.h>
 #include <sys/sem.h>
 
-#include <infiniband/arch.h>
 #include <rdma/rdma_cma.h>
 
 #include "log.h"


### PR DESCRIPTION
This patch remove an obsoletes include from infiniband leading to this
compilation error :

    $ make
    Making all in src
    make[1]: Entering directory '/builddir/build/BUILD/libmooshika-1.0/src'
    Making all in .
    make[2]: Entering directory '/builddir/build/BUILD/libmooshika-1.0/src'
    gcc -DHAVE_CONFIG_H -I. -I../include    -g -D_REENTRANT -Wall -Wimplicit -Wformat -Wmissing-braces -Wno-pointer-sign -Werror -I./../include -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -c -o rcat.o rcat.c
    In file included from ../include/mooshika.h:35,
                     from rcat.c:48:
    /usr/include/infiniband/arch.h:37:2: error: #warning "This header is obsolete." [-Werror=cpp]
     #warning "This header is obsolete."
      ^~~~~~~
    cc1: all warnings being treated as errors
    make[2]: Leaving directory '/builddir/build/BUILD/libmooshika-1.0/src'
    make[2]: *** [Makefile:556: rcat.o] Error 1
    make[1]: Leaving directory '/builddir/build/BUILD/libmooshika-1.0/src'
    make[1]: *** [Makefile:606: all-recursive] Error 1
    make: *** [Makefile:452: all-recursive] Error 1